### PR TITLE
fix: CC-13 Prevent bottom of page from being cut off on iOS

### DIFF
--- a/src/components/PageWrapper/PageWrapper.module.scss
+++ b/src/components/PageWrapper/PageWrapper.module.scss
@@ -9,6 +9,7 @@ $header-height: 2.5rem;
 
   flex-grow: 1;
   min-height: 0;
+  padding-bottom: calc(100vh - 100dvh); // Prevent browser toolbar from cutting off bottom of page
 
   &_Banner {
     @include flex.column;


### PR DESCRIPTION
Fixes #13