### PR TITLE
#138 Remove storage ID empty strings from tournament form

### DIFF
--- a/src/components/TournamentForm/TournamentForm.schema.ts
+++ b/src/components/TournamentForm/TournamentForm.schema.ts
@@ -48,8 +48,8 @@ export const tournamentFormSchema = z.object({
   startsAt: z.string(), // Local time 0000-00-00T00:00
   endsAt: z.string(), // Local time 0000-00-00T00:00
   registrationClosesAt: z.string(),
-  logoStorageId: z.optional(z.string().transform((val) => val as StorageId)),
-  bannerStorageId: z.optional(z.string().transform((val) => val as StorageId)),
+  logoStorageId: z.preprocess((val) => val === '' ? undefined : val, z.string().optional().transform((val) => val as StorageId)),
+  bannerStorageId: z.preprocess((val) => val === '' ? undefined : val, z.string().optional().transform((val) => val as StorageId)),
 
   // Competitor Config
   maxCompetitors: z.coerce.number().min(2, 'Tournaments require at least two competitors.'),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty values for logo and banner fields in tournament forms, ensuring empty fields are treated as missing rather than invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->