### PR TITLE
#136 fix: Correctly show ConfigureRound, StartRound and End actions for tournaments

### DIFF
--- a/convex/_model/tournaments/queries/getAvailableTournamentActions.ts
+++ b/convex/_model/tournaments/queries/getAvailableTournamentActions.ts
@@ -67,11 +67,11 @@ export const getAvailableTournamentActions = async (
     actions.push(TournamentActionKey.Start);
   }
 
-  if (isOrganizer && !hasCurrentRound && hasNextRound && nextRoundPairingCount === 0) {
+  if (isOrganizer && tournament.status === 'active' && !hasCurrentRound && hasNextRound && nextRoundPairingCount === 0) {
     actions.push(TournamentActionKey.ConfigureRound);
   }
 
-  if (isOrganizer && !hasCurrentRound && hasNextRound && nextRoundPairingCount > 0) {
+  if (isOrganizer && tournament.status === 'active' && !hasCurrentRound && hasNextRound && nextRoundPairingCount > 0) {
     actions.push(TournamentActionKey.StartRound);
   }
 
@@ -83,7 +83,7 @@ export const getAvailableTournamentActions = async (
     actions.push(TournamentActionKey.EndRound);
   }
 
-  if (isOrganizer && !hasCurrentRound) {
+  if (isOrganizer && tournament.status === 'active' && !hasCurrentRound) {
     actions.push(TournamentActionKey.End);
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Organizer-specific tournament actions such as configuring rounds, starting rounds, and ending tournaments are now only available when the tournament status is set to "active". This ensures these actions are restricted to ongoing tournaments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->