### PR TITLE
#168 Configure round action not visible between rounds

### DIFF
--- a/convex/_model/matchResults/queries/getMatchResultsByTournamentRound.ts
+++ b/convex/_model/matchResults/queries/getMatchResultsByTournamentRound.ts
@@ -13,8 +13,7 @@ export const getMatchResultsByTournamentRound = async (
   args: Infer<typeof getMatchResultsByTournamentRoundArgs>,
 ): Promise<DeepMatchResult[]> => {
   const tournamentPairings = await ctx.db.query('tournamentPairings')
-    .withIndex('by_tournament_id', (q) => q.eq('tournamentId', args.tournamentId))
-    .filter((q) => q.eq(q.field('round'), args.round))
+    .withIndex('by_tournament_round', (q) => q.eq('tournamentId', args.tournamentId).eq('round', args.round))
     .collect();
   const matchResults = await ctx.db.query('matchResults')
     .withIndex('by_tournament_id', (q) => q.eq('tournamentId', args.tournamentId))

--- a/convex/_model/tournamentPairings/index.ts
+++ b/convex/_model/tournamentPairings/index.ts
@@ -7,7 +7,8 @@ export const tournamentPairingsTable = defineTable({
   ...editableFields,
   ...computedFields,
 })
-  .index('by_tournament_id', ['tournamentId']);
+  .index('by_tournament_id', ['tournamentId'])
+  .index('by_tournament_round', ['tournamentId', 'round']);
 
 export type TournamentPairingId = Id<'tournamentPairings'>;
 export type ShallowTournamentPairing = Doc<'tournamentPairings'>;

--- a/convex/_model/tournaments/queries/getAvailableTournamentActions.ts
+++ b/convex/_model/tournaments/queries/getAvailableTournamentActions.ts
@@ -37,7 +37,7 @@ export const getAvailableTournamentActions = async (
   // ---- GATHER DATA ----
   const nextRound = getTournamentNextRound(tournament);
   const nextRoundPairings = await ctx.db.query('tournamentPairings')
-    .withIndex('by_tournament_id', (q) => q.eq('tournamentId', args.id))
+    .withIndex('by_tournament_round', (q) => q.eq('tournamentId', args.id).eq('round', nextRound ?? -1))
     .collect();
   const nextRoundPairingCount = (nextRoundPairings ?? []).length;
   const playerUserIds = await getTournamentPlayerUserIds(ctx, tournament._id);

--- a/convex/_model/tournaments/queries/getTournamentOpenRound.ts
+++ b/convex/_model/tournaments/queries/getTournamentOpenRound.ts
@@ -29,8 +29,7 @@ export const getTournamentOpenRound = async (
     return null;
   }
   const tournamentPairings = await ctx.db.query('tournamentPairings')
-    .withIndex('by_tournament_id', (q) => q.eq('tournamentId', args.id))
-    .filter((q) => q.eq(q.field('round'), tournament.currentRound))
+    .withIndex('by_tournament_round', (q) => q.eq('tournamentId', args.id).eq('round', tournament.currentRound ?? -1))
     .collect();
   const matchResults = await ctx.db.query('matchResults')
     .withIndex('by_tournament_id', (q) => q.eq('tournamentId', args.id))

--- a/convex/_model/utils/createTestTournamentMatchResults.ts
+++ b/convex/_model/utils/createTestTournamentMatchResults.ts
@@ -23,8 +23,7 @@ export const createTestTournamentMatchResults = async (
     throw new Error('Tournament does not have a current round!');
   }
   const tournamentPairings = await ctx.db.query('tournamentPairings')
-    .withIndex('by_tournament_id', (q) => q.eq('tournamentId', tournamentId))
-    .filter((q) => q.eq(q.field('round'), tournament.currentRound))
+    .withIndex('by_tournament_round', (q) => q.eq('tournamentId', tournamentId).eq('round', tournament.currentRound ?? -1))
     .collect();
   if (tournamentPairings.length < 1) {
     throw new Error('No pairings to create results for!');


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved efficiency of tournament pairing queries by consolidating filters into a single indexed query, resulting in faster and more precise results when viewing tournament rounds and match results.

* **Chores**
  * Added a new database index to optimize tournament pairing lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary by a Real Human

* **The Actual Important Bit: Bug Fixes**
  * The configure round action now correctly renders in-between tournament rounds.