### PR TITLE
#181 Improve list data import

### DIFF
--- a/convex/_model/lists/mutations/importListData.ts
+++ b/convex/_model/lists/mutations/importListData.ts
@@ -14,11 +14,13 @@ const nanoid = customAlphabet('1234567890abcdefghijklmnopqrstuvwxyz', 6);
 export const importListDataArgs = v.object({
   pointsLimit: v.number(),
   data: v.array(v.object({
-    playerUserId: v.id('users'),
-    tournamentCompetitorId: v.id('tournamentCompetitors'),
+    displayName: v.optional(v.string()), // Not used, but allowed because its handy in the raw data.
     forceDiagram,
     formations: v.array(formation),
+    playerUserId: v.id('users'),
+    tournamentCompetitorId: v.id('tournamentCompetitors'),
   })),
+  locked: v.boolean(),
 });
 
 export const importListData = async (
@@ -41,6 +43,7 @@ export const importListData = async (
         units: [],
         commandCards: [],
       },
+      locked: args.locked,
     });
     const competitor = await ctx.db.get(row.tournamentCompetitorId);
     if (competitor) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - You can now mark a list as locked during import. Newly created lists will respect this lock state, aligning with existing read-only behavior for locked lists.
  - The importer accepts an optional display name for each item in the data. This field is tolerated for compatibility but does not affect current display or behavior.
- Documentation
  - Updated import guidance to note the new locked flag and optional item display name support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->