### PR TITLE
#185 Attach ETC 2025 lists to match results

### DIFF
--- a/convex/_model/matchResults/fields.ts
+++ b/convex/_model/matchResults/fields.ts
@@ -13,8 +13,10 @@ export const editableFields = {
   // Players
   player0UserId: v.optional(v.id('users')),
   player0Placeholder: v.optional(v.string()),
+  player0ListId: v.optional(v.id('lists')),
   player1UserId: v.optional(v.id('users')),
   player1Placeholder: v.optional(v.string()),
+  player1ListId: v.optional(v.id('lists')),  
 
   // General
   playedAt: v.union(v.string(), v.number()),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Match results now include linked player lists for each participant (when available), providing more context alongside player info.

* **Chores**
  * Backfilled existing match results to attach player list links based on tournament data; no user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->