### PR TITLE
#145 Tournament registration fixes

### DIFF
--- a/convex/_model/tournamentCompetitors/mutations/createTournamentCompetitor.ts
+++ b/convex/_model/tournamentCompetitors/mutations/createTournamentCompetitor.ts
@@ -44,7 +44,7 @@ export const createTournamentCompetitor = async (
     .withIndex('by_tournament_user', (q) => q.eq('tournamentId', tournament._id).eq('userId', args.captainUserId))
     .first();
   if (existingTournamentRegistration) {
-    throw new ConvexError({ userId: args.captainUserId, existingTournamentRegistration });
+    throw new ConvexError(getErrorMessage('USER_ALREADY_IN_TOURNAMENT'));
   }
   if (!args.captainUserId) {
     throw new ConvexError(getErrorMessage('CANNOT_CREATE_COMPETITOR_WITH_0_PLAYERS'));

--- a/convex/_model/tournamentOrganizers/mutations/createTournamentOrganizer.ts
+++ b/convex/_model/tournamentOrganizers/mutations/createTournamentOrganizer.ts
@@ -38,7 +38,10 @@ export const createTournamentOrganizer = async (
   /* These user IDs can make changes to this tournament organizer:
    * - Tournament organizers;
    */
-  const authorizedUserIds = tournamentOrganizers.map((to) => to.userId);
+  const authorizedUserIds = [
+    ...tournamentOrganizers.map((to) => to.userId),
+    ...(tournamentOrganizers.length === 0 ? [args.userId] : []),
+  ];
   if (!authorizedUserIds.includes(userId)) {
     throw new ConvexError(getErrorMessage('USER_DOES_NOT_HAVE_PERMISSION'));
   }

--- a/src/components/TournamentCompetitorForm/TournamentCompetitorForm.tsx
+++ b/src/components/TournamentCompetitorForm/TournamentCompetitorForm.tsx
@@ -55,7 +55,7 @@ export const TournamentCompetitorForm = ({
   // Get other competitors, we can block repeat names:
   const otherCompetitors = (tournamentCompetitors || []).filter((c) => c._id !== tournamentCompetitor?._id);
 
-  const formSchema = createSchema(!tournamentCompetitor ? 'create' : 'update', otherCompetitors);
+  const formSchema = createSchema(!tournamentCompetitor ? 'create' : 'update', tournament.useTeams, otherCompetitors);
   const form = useForm<TournamentCompetitorFormData>({
     defaultValues: {
       ...getDefaultValues(!isOrganizer ? (user?._id) : undefined),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Team name is only required when the tournament uses teams; duplicate team checks also apply only then.
  - Captains can now manage (delete) their own tournament competitor entries.
  - When no organizers exist, the first organizer can self-create to bootstrap management.

- Bug Fixes
  - Deleting a competitor now also removes their related registrations to prevent leftover data.

- Improvements
  - Standardized error when a user is already registered for a tournament, providing a clearer, consistent message without exposing extra details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->