### PR TITLE
#194 Make draft tournaments visible to their owner

### DIFF
--- a/src/components/TournamentCard/TournamentCard.tsx
+++ b/src/components/TournamentCard/TournamentCard.tsx
@@ -4,6 +4,7 @@ import { ChevronRight } from 'lucide-react';
 import { Tournament } from '~/api';
 import { useAuth } from '~/components/AuthProvider';
 import { Button } from '~/components/generic/Button';
+import { Tag } from '~/components/generic/Tag';
 import { TournamentActionsProvider } from '~/components/TournamentActionsProvider';
 import { TournamentContextMenu } from '~/components/TournamentContextMenu';
 import { TournamentInfoBlock } from '~/components/TournamentInfoBlock/';
@@ -62,6 +63,9 @@ export const TournamentCard = ({
           </div>
           <div className={styles.TournamentCard_Title}>
             <h2>{getTournamentDisplayName(tournament)}</h2>
+            {tournament.status === 'draft' && (
+              <Tag>Draft</Tag>
+            )}
             <div className={styles.TournamentCard_Buttons}>
               {showContextMenu && (
                 <TournamentContextMenu />

--- a/src/components/TournamentRoster/TournamentRoster.tsx
+++ b/src/components/TournamentRoster/TournamentRoster.tsx
@@ -27,6 +27,8 @@ export const TournamentRoster = ({
 
   const competitors = useTournamentCompetitors();
   const { mutation: toggleActive } = useToggleTournamentRegistrationActive();
+
+  const showActiveToggle = isOrganizer && tournament.status === 'active' && tournament.currentRound === undefined;
   return (
     <Accordion className={className}>
       {(competitors || []).map((competitor) => (
@@ -40,9 +42,9 @@ export const TournamentRoster = ({
           </div>
           <div className={styles.TournamentRoster_Content}>
             {competitor.registrations.map((r) => (
-              <div className={styles.TournamentRoster_RegistrationRow}>
+              <div key={r._id} className={styles.TournamentRoster_RegistrationRow}>
                 <IdentityBadge key={r.user?._id} user={r.user} size="small" />
-                {isOrganizer && (
+                {showActiveToggle && (
                   <div className={styles.TournamentRoster_RegistrationSwitch}>
                     <Label>Active</Label>
                     <Switch

--- a/src/pages/TournamentsPage/TournamentsPage.tsx
+++ b/src/pages/TournamentsPage/TournamentsPage.tsx
@@ -32,7 +32,9 @@ export const TournamentsPage = (): JSX.Element => {
 
   type StatusGroup = Exclude<Tournament['status'], 'draft'>;
   const { active, archived, published } = (tournaments ?? []).reduce((acc, t) => {
-    if (t.status in acc) {
+    if (t.status === 'draft') {
+      acc.published.push(t);
+    } else {
       acc[t.status as StatusGroup].push(t);
     }
     return acc;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Display a “Draft” tag on tournament cards, clarifying status at a glance.

* **Bug Fixes**
  * Draft tournaments now appear in the Upcoming section instead of being omitted.
  * Active toggle is only shown to organizers when the tournament is active and has no current round, preventing unintended visibility.
  * Improved roster list stability by adding keys to registration rows to avoid rendering glitches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->