### PR TITLE
#193 Tournament info block text overflows on mobile

### DIFF
--- a/src/components/TournamentInfoBlock/TournamentInfoBlock.module.scss
+++ b/src/components/TournamentInfoBlock/TournamentInfoBlock.module.scss
@@ -10,13 +10,14 @@
 .TournamentInfoBlock {
   @include flex.column($gap: 0.5rem);
 
-  overflow: hidden;
-
   &_InfoLine {
-    @include flex.row($yAlign: top, $gap: 0.5rem);
     @include text.ui;
 
     overflow: hidden;
+    display: grid;
+    grid-template-columns: 1rem 1fr;
+    column-gap: 0.5rem;
+
     min-width: 0;
 
     a {
@@ -24,22 +25,19 @@
       line-height: inherit;
     }
 
-    &_Content {
-      min-width: 0;
+    svg {
+      grid-column: 1/2;
+      flex-shrink: 0;
+      width: 1rem;
+      height: 1rem;
     }
 
     span {
       @include text.single-line;
 
       display: block;
+      grid-column: 2/-1;
       min-width: 0;
-    }
-
-    svg {
-      flex-shrink: 0;
-      width: 1rem;
-      height: 1rem;
-      margin: calc((var(--line-height-normal) - 1rem) / 2);
     }
   }
 }

--- a/src/components/TournamentInfoBlock/TournamentInfoBlock.tsx
+++ b/src/components/TournamentInfoBlock/TournamentInfoBlock.tsx
@@ -40,17 +40,13 @@ export const TournamentInfoBlock = ({
         <>
           <div className={styles.TournamentInfoBlock_InfoLine}>
             <CalendarClock />
-            <div className={styles.TournamentInfoBlock_InfoLine_Content}>
-              <span>{format(tournament.startsAt, 'd MMM yyy, p')}</span>
-              <span>{format(tournament.endsAt, 'd MMM yyyy, p')}</span>
-            </div>
+            <span>{format(tournament.startsAt, 'd MMM yyy, p')}</span>
+            <span>{format(tournament.endsAt, 'd MMM yyyy, p')}</span>
           </div>
           <div className={styles.TournamentInfoBlock_InfoLine}>
             <MapPin />
-            <div className={styles.TournamentInfoBlock_InfoLine_Content}>
-              <span>{tournament.location.name}</span>
-              <span>{tournament.location.placeFormatted}</span>
-            </div>
+            <span>{tournament.location.name}</span>
+            <span>{tournament.location.placeFormatted}</span>
           </div>
           <div className={styles.TournamentInfoBlock_InfoLine}>
             <Users />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Tournament Info layout to a two-column grid for cleaner alignment.
  * Streamlined markup by removing unnecessary wrappers.
  * Standardized icon sizing and positioning for consistent visuals.
  * Improved single-line truncation for content text.

* **Bug Fixes**
  * Reduced unexpected overflow/clipping in Tournament Info content.
  * More reliable alignment and truncation for long dates and location names across browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->