### PR TITLE
#209 Hotfix: Make listSubmissionClosesAt optional

### DIFF
--- a/convex/_model/tournaments/table.ts
+++ b/convex/_model/tournaments/table.ts
@@ -34,7 +34,7 @@ export const editableFields = {
   startsAt: v.union(v.number(), v.string()),
   endsAt: v.union(v.number(), v.string()),
   registrationClosesAt: v.union(v.number(), v.string()),
-  listSubmissionClosesAt: v.union(v.number(), v.string()),
+  listSubmissionClosesAt: v.optional(v.union(v.number(), v.string())),
 
   requireRealNames: v.boolean(),
   organizerUserIds: v.optional(v.array(v.id('users'))),

--- a/src/components/TournamentForm/TournamentForm.tsx
+++ b/src/components/TournamentForm/TournamentForm.tsx
@@ -51,7 +51,7 @@ export const TournamentForm = ({
         startsAt: typeof tournament.startsAt === 'string' ? convertStringToDate(tournament.startsAt, tournament.location.timeZone) : convertEpochToDate(tournament.startsAt, tournament.location.timeZone),
         endsAt: typeof tournament.endsAt === 'string' ? convertStringToDate(tournament.endsAt, tournament.location.timeZone) : convertEpochToDate(tournament.endsAt, tournament.location.timeZone),
         registrationClosesAt: typeof tournament.registrationClosesAt === 'string' ? convertStringToDate(tournament.registrationClosesAt, tournament.location.timeZone) : convertEpochToDate(tournament.registrationClosesAt, tournament.location.timeZone),
-        listSubmissionClosesAt: typeof tournament.listSubmissionClosesAt === 'string' ? convertStringToDate(tournament.listSubmissionClosesAt, tournament.location.timeZone) : convertEpochToDate(tournament.listSubmissionClosesAt, tournament.location.timeZone),
+        listSubmissionClosesAt: typeof tournament.listSubmissionClosesAt === 'string' ? convertStringToDate(tournament.listSubmissionClosesAt, tournament.location.timeZone) : convertEpochToDate(tournament.listSubmissionClosesAt ?? 0, tournament.location.timeZone),
       } : {}),
     },
     mode: 'onSubmit',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Made the “List Submission Deadline” optional in tournament creation and editing.

- Bug Fixes
  - Prevented errors when opening tournaments that don’t have a “List Submission Deadline.”
  - Improved default date handling to ensure the form displays valid values even when the deadline is missing.
  - Increased reliability of the tournament form when saving or editing entries without this field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->