### PR TITLE
#216 Min width prevents users from viewing site

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,24 +1,13 @@
 import { Outlet, useLocation } from 'react-router-dom';
-import { useWindowWidth } from '@react-hook/window-size/throttled';
-import clsx from 'clsx';
 
 import { AppBar } from '~/components/AppBar';
 import { ErrorBoundary } from '~/components/ErrorBoundary';
-import { MAX_WIDTH, MIN_WIDTH } from '~/settings';
+import { MAX_WIDTH } from '~/settings';
 
 import styles from './App.module.scss';
 
 export const App = (): JSX.Element => {
   const location = useLocation();
-  const width = useWindowWidth();
-  if (width < MIN_WIDTH) {
-    return (
-      <div className={clsx(styles.App, styles['App-minWidthError'])}>
-        <h3>Please use a larger device to use CombatCommand.</h3>
-        <p>If you are currently using your phone in landscape mode, please turn it to portrait mode.</p>
-      </div>
-    );
-  }
   return (
     <div className={styles.App}>
       <AppBar maxWidth={MAX_WIDTH} />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Removed the minimum window width restriction. The app now works on smaller screens and narrow browser windows.
  * The standard layout is always displayed; the previous min-width warning screen has been eliminated for a smoother experience.
  * Improved accessibility and continuity of navigation on compact devices and resized windows, without interruptions from width-related prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->