### PR TITLE
#240 Match result form does not inherit game system config

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -167,6 +167,7 @@ import type * as _model_tournaments_mutations_startTournamentRound from "../_mod
 import type * as _model_tournaments_mutations_updateTournament from "../_model/tournaments/mutations/updateTournament.js";
 import type * as _model_tournaments_queries_getAvailableTournamentActions from "../_model/tournaments/queries/getAvailableTournamentActions.js";
 import type * as _model_tournaments_queries_getTournament from "../_model/tournaments/queries/getTournament.js";
+import type * as _model_tournaments_queries_getTournamentByTournamentPairing from "../_model/tournaments/queries/getTournamentByTournamentPairing.js";
 import type * as _model_tournaments_queries_getTournamentOpenRound from "../_model/tournaments/queries/getTournamentOpenRound.js";
 import type * as _model_tournaments_queries_getTournamentRankings from "../_model/tournaments/queries/getTournamentRankings.js";
 import type * as _model_tournaments_queries_getTournaments from "../_model/tournaments/queries/getTournaments.js";
@@ -414,6 +415,7 @@ declare const fullApi: ApiFromModules<{
   "_model/tournaments/mutations/updateTournament": typeof _model_tournaments_mutations_updateTournament;
   "_model/tournaments/queries/getAvailableTournamentActions": typeof _model_tournaments_queries_getAvailableTournamentActions;
   "_model/tournaments/queries/getTournament": typeof _model_tournaments_queries_getTournament;
+  "_model/tournaments/queries/getTournamentByTournamentPairing": typeof _model_tournaments_queries_getTournamentByTournamentPairing;
   "_model/tournaments/queries/getTournamentOpenRound": typeof _model_tournaments_queries_getTournamentOpenRound;
   "_model/tournaments/queries/getTournamentRankings": typeof _model_tournaments_queries_getTournamentRankings;
   "_model/tournaments/queries/getTournaments": typeof _model_tournaments_queries_getTournaments;

--- a/convex/_model/tournaments/index.ts
+++ b/convex/_model/tournaments/index.ts
@@ -70,6 +70,10 @@ export {
   getTournamentArgs,
 } from './queries/getTournament';
 export {
+  getTournamentByTournamentPairing,
+  getTournamentByTournamentPairingArgs,
+} from './queries/getTournamentByTournamentPairing';
+export {
   getTournamentOpenRound,
   getTournamentOpenRoundArgs,
   type TournamentOpenRound,

--- a/convex/_model/tournaments/queries/getTournamentByTournamentPairing.ts
+++ b/convex/_model/tournaments/queries/getTournamentByTournamentPairing.ts
@@ -1,0 +1,23 @@
+import { Infer, v } from 'convex/values';
+
+import { QueryCtx } from '../../../_generated/server';
+import { deepenTournament, TournamentDeep } from '../_helpers/deepenTournament';
+
+export const getTournamentByTournamentPairingArgs = v.object({
+  tournamentPairingId: v.id('tournamentPairings'),
+});
+
+export const getTournamentByTournamentPairing = async (
+  ctx: QueryCtx,
+  args: Infer<typeof getTournamentByTournamentPairingArgs>,
+): Promise<TournamentDeep | null> => {
+  const tournamentPairing = await ctx.db.get(args.tournamentPairingId);
+  if (!tournamentPairing) {
+    return null;
+  }
+  const tournament = await ctx.db.get(tournamentPairing.tournamentId);
+  if (!tournament) {
+    return null;
+  }
+  return await deepenTournament(ctx, tournament);
+};

--- a/convex/tournaments.ts
+++ b/convex/tournaments.ts
@@ -11,6 +11,11 @@ export const getTournament = query({
   handler: model.getTournament,
 });
 
+export const getTournamentByTournamentPairing = query({
+  args: model.getTournamentByTournamentPairingArgs,
+  handler: model.getTournamentByTournamentPairing,
+});
+
 export const getTournaments = query({
   handler: model.getTournaments,
 });

--- a/src/components/FowV4MatchResultForm/FowV4MatchResultForm.tsx
+++ b/src/components/FowV4MatchResultForm/FowV4MatchResultForm.tsx
@@ -19,6 +19,7 @@ import { Separator } from '~/components/generic/Separator';
 import { useAsyncState } from '~/hooks/useAsyncState';
 import { useCreateMatchResult, useUpdateMatchResult } from '~/services/matchResults';
 import { useGetActiveTournamentPairingsByUser } from '~/services/tournamentPairings';
+import { useGetTournamentByTournamentPairing } from '~/services/tournaments';
 import { getTournamentPairingDisplayName } from '~/utils/common/getTournamentPairingDisplayName';
 import { validateForm } from '~/utils/validateForm';
 import { CommonFields } from './components/CommonFields';
@@ -68,6 +69,12 @@ export const FowV4MatchResultForm = ({
     data: tournamentPairings,
     loading: tournamentPairingsLoading,
   } = useGetActiveTournamentPairingsByUser(user ? { userId: user._id } : 'skip');
+  const {
+    data: tournament,
+    loading: tournamentLoading,
+  } = useGetTournamentByTournamentPairing(tournamentPairingId !== 'single' ? {
+    tournamentPairingId,
+  } : 'skip');
 
   const {
     mutation: createMatchResult,
@@ -82,7 +89,7 @@ export const FowV4MatchResultForm = ({
     onSuccess,
   });
 
-  const disabled = createMatchResultPending || updateMatchResultPending;
+  const disabled = createMatchResultPending || updateMatchResultPending || tournamentLoading;
 
   useEffect(() => {
     if (onStatusChange) {
@@ -97,6 +104,12 @@ export const FowV4MatchResultForm = ({
     },
     mode: 'onSubmit',
   });
+
+  useEffect(() => {
+    if (tournament) {
+      form.setValue('gameSystemConfig', tournament.gameSystemConfig);
+    }
+  }, [tournament, form]);
 
   const playerNames = usePlayerDisplayNames(form.watch());
 

--- a/src/components/FowV4MatchResultForm/components/CommonFields.tsx
+++ b/src/components/FowV4MatchResultForm/components/CommonFields.tsx
@@ -32,6 +32,8 @@ export const CommonFields = (): JSX.Element => {
 
   const selectedMission = getMission(missionPackVersion, details?.mission);
 
+  const showDisabled = !details?.player0BattlePlan || !details?.player1BattlePlan;
+
   // Auto-fill attacker, if possible
   const autoAttacker = computeAttacker(selectedMission, [details?.player0BattlePlan, details?.player1BattlePlan]);
   const disableAttackerField = autoAttacker !== undefined;
@@ -76,33 +78,37 @@ export const CommonFields = (): JSX.Element => {
 
   return (
     <div className={styles.CommonFields}>
-      <FormField name="details.mission" label="Mission">
+      <FormField name="details.mission" label="Mission" disabled={showDisabled}>
         <InputSelect options={missionOptions} />
       </FormField>
-      <FormField name="details.attacker" label="Attacker" disabled={disableAttackerField}>
+      <FormField name="details.attacker" label="Attacker" disabled={showDisabled || disableAttackerField}>
         <InputSelect options={playerOptions} />
       </FormField>
-      <FormField name="details.firstTurn" label="First Turn" disabled={disableFirstTurnField}>
+      <FormField name="details.firstTurn" label="First Turn" disabled={showDisabled || disableFirstTurnField}>
         <InputSelect options={playerOptions} />
       </FormField>
       <div className={styles.CommonFields_OutcomeSection}>
-        <FormField name="details.turnsPlayed" label="Turns Played">
+        <FormField name="details.turnsPlayed" label="Turns Played" disabled={showDisabled}>
           <InputText type="number" />
         </FormField>
-        <FormField name="details.outcomeType" label="Outcome Type">
+        <FormField name="details.outcomeType" label="Outcome Type" disabled={showDisabled}>
           <InputSelect options={outcomeTypeOptions} />
         </FormField>
       </div>
-      <FormField name="details.winner" label="Winner" disabled={disableWinner}>
+      <FormField name="details.winner" label="Winner" disabled={showDisabled || disableWinner}>
         <InputSelect options={winnerOptions} />
       </FormField>
-      <FormField label="Use custom score">
+      <FormField label="Use custom score" disabled={showDisabled}>
         <Switch checked={showScoreOverride} onCheckedChange={handleToggleScoreOverride} />
       </FormField>
       {showScoreOverride && (
         <div className={styles.CommonFields_ScoreOverrideSection}>
           {([0, 1] as const).map((i) => (
-            <FormField name={`details.scoreOverride.player${i}Score`} label={getScoreOverrideLabel(i)}>
+            <FormField
+              name={`details.scoreOverride.player${i}Score`}
+              label={getScoreOverrideLabel(i)}
+              disabled={showDisabled}
+            >
               <InputText type="number" />
             </FormField>
           ))}

--- a/src/components/FowV4MatchResultForm/components/GameConfigFields.schema.ts
+++ b/src/components/FowV4MatchResultForm/components/GameConfigFields.schema.ts
@@ -54,7 +54,7 @@ export const fowV4GameSystemConfigDefaultValues: FowV4GameSystemConfigFormData =
 
   // Non-editable
   dynamicPointsVersion: undefined,
-  missionMatrix: 'default',
-  missionPackVersion: MissionPackVersion.Jul2024,
+  missionMatrix: 'extended',
+  missionPackVersion: MissionPackVersion.Apr2023,
   useExperimentalMissions: true,
 };

--- a/src/services/tournaments.ts
+++ b/src/services/tournaments.ts
@@ -8,11 +8,12 @@ export const useGetTournaments = createQueryHook(api.tournaments.getTournaments)
 
 // Special Queries
 export const useGetAvailableTournamentActions = createQueryHook(api.tournaments.getAvailableTournamentActions);
+export const useGetTournamentByTournamentPairing = createQueryHook(api.tournaments.getTournamentByTournamentPairing);
 export const useGetTournamentOpenRound = createQueryHook(api.tournaments.getTournamentOpenRound);
-export type TournamentOpenRound = typeof api.tournaments.getTournamentOpenRound._returnType; // TODO: Move to back-end
 export const useGetTournamentRankings = createQueryHook(api.tournaments.getTournamentRankings);
 export const useGetTournamentsByStatus = createQueryHook(api.tournaments.getTournamentsByStatus);
 export const useGetTournamentsByUser = createQueryHook(api.tournaments.getTournamentsByUser);
+export type TournamentOpenRound = typeof api.tournaments.getTournamentOpenRound._returnType; // TODO: Move to back-end
 
 // Basic (C_UD) Mutations
 export const useCreateTournament = createMutationHook(api.tournaments.createTournament);


### PR DESCRIPTION
**Resolves:** #240 

---

Effectively reverts:

- [`b4d4abb3354f48971fb04462a23c06ae7d9a0114`](https://github.com/ianpaschal/combat-command/commit/b4d4abb3354f48971fb04462a23c06ae7d9a0114)
- [`6721cabd2251f7a812a2783b3c890c5062cea8ec`](https://github.com/ianpaschal/combat-command/commit/6721cabd2251f7a812a2783b3c890c5062cea8ec)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Match result form auto-populates game system configuration based on the linked tournament.
- Improvements
  - Form fields are now disabled while tournament data loads to prevent premature edits.
  - Additional safeguards disable fields when required battle plans are missing.
  - Default mission settings updated: uses Extended mission matrix and Apr 2023 mission pack version.
- Performance/UX
  - More reliable tournament retrieval by pairing, ensuring accurate context for match submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->