### PR TITLE
#250 Migration (Part C)

### DIFF
--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -99,3 +99,29 @@ export const setMissingTournamentDynamicPointsVersions = migrations.define({
   table: 'tournaments',
   migrateOne: setDefaultDynamicPoints,
 });
+
+const removeExperimentalMissionOption = async (
+  ctx: MutationCtx,
+  doc: Doc<'matchResults'> | Doc<'tournaments'>,
+): Promise<void> => {
+  // @ts-expect-error This is a migration.
+  if (doc.gameSystemConfig?.useExperimentalMissions !== undefined) {
+    return await ctx.db.patch(doc._id, {
+      gameSystemConfig: {
+        ...doc.gameSystemConfig,
+        // @ts-expect-error This is a migration.
+        useExperimentalMissions: undefined,
+      },
+    });
+  }
+};
+
+export const removeMatchResultExperimentalMissionOption = migrations.define({
+  table: 'matchResults',
+  migrateOne: removeExperimentalMissionOption,
+});
+
+export const removeTournamentExperimentalMissionOption = migrations.define({
+  table: 'tournaments',
+  migrateOne: removeExperimentalMissionOption,
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up legacy data by removing the deprecated “experimental missions” setting from existing match results and tournaments.
  * Aligned stored configurations with current app behavior; no changes to how results are displayed or managed.
  * No action required from users; historical data remains intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->