### PR TITLE
#281 Correctly show Dynamic Points Version field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@fontsource/figtree": "^5.1.0",
         "@hookform/resolvers": "^3.9.0",
         "@ianpaschal/combat-command-components": "^1.8.0",
-        "@ianpaschal/combat-command-game-systems": "^1.2.0",
+        "@ianpaschal/combat-command-game-systems": "^1.3.0",
         "@mapbox/search-js-core": "^1.0.0-beta.25",
         "@radix-ui/colors": "^3.0.0",
         "@react-hook/window-size": "^3.1.1",
@@ -1558,9 +1558,9 @@
       }
     },
     "node_modules/@ianpaschal/combat-command-game-systems": {
-      "version": "1.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@ianpaschal/combat-command-game-systems/1.2.0/f7e4d868c759e727dc98f2190d24073d028f46be",
-      "integrity": "sha512-au90rG1BI95tmsq0Pfz0WRdfaJ8bk8A1FzGrfRbuQomXpQKb4QxOLLcqBBgHewpwgMj52TPzBM/FEye6A5WnmQ==",
+      "version": "1.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@ianpaschal/combat-command-game-systems/1.3.0/ff6b5b4b8e28839b748695f2b80ccb3f4e18f6fc",
+      "integrity": "sha512-XjAdDrDlXeKiktoNzfQ5bBe+NuwCssE/QEjOIQ67P2wYYgMRutUzM3ZKk159G0lAFk5KLLOEfYps6cK2abQd6Q==",
       "license": "UNLICENSED",
       "dependencies": {
         "zod": "^3.25.76"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@fontsource/figtree": "^5.1.0",
     "@hookform/resolvers": "^3.9.0",
     "@ianpaschal/combat-command-components": "^1.8.0",
-    "@ianpaschal/combat-command-game-systems": "^1.2.0",
+    "@ianpaschal/combat-command-game-systems": "^1.3.0",
     "@mapbox/search-js-core": "^1.0.0-beta.25",
     "@radix-ui/colors": "^3.0.0",
     "@react-hook/window-size": "^3.1.1",

--- a/src/components/GameSystemConfigFields/gameSystems/FlamesOfWarV4GameSystemConfigFields/FlamesOfWarV4GameSystemConfigFields.module.scss
+++ b/src/components/GameSystemConfigFields/gameSystems/FlamesOfWarV4GameSystemConfigFields/FlamesOfWarV4GameSystemConfigFields.module.scss
@@ -16,6 +16,6 @@
   }
 
   &_Rules {
-    @include flex.column;
+    @include flex.stackable;
   }
 }

--- a/src/components/GameSystemConfigFields/gameSystems/FlamesOfWarV4GameSystemConfigFields/FlamesOfWarV4GameSystemConfigFields.tsx
+++ b/src/components/GameSystemConfigFields/gameSystems/FlamesOfWarV4GameSystemConfigFields/FlamesOfWarV4GameSystemConfigFields.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import {
+  getDynamicPointsVersionOptions,
   getEraOptions,
   getLessonsFromTheFrontVersionOptions,
   getMissionMatrixOptions,
   getMissionPackVersionOptions,
-  MissionMatrix,
 } from '@ianpaschal/combat-command-game-systems/flamesOfWarV4';
 import clsx from 'clsx';
 
@@ -35,12 +35,11 @@ export const FlamesOfWarV4GameSystemConfigFields = ({
   const missionMatrixOptions = getMissionMatrixOptions(gameSystemConfig.missionPackVersion);
   const lessonsFromTheFrontVersionOptions = getLessonsFromTheFrontVersionOptions();
   const missionPackVersionOptions = getMissionPackVersionOptions();
+  const dynamicPointsVersionOptions = getDynamicPointsVersionOptions(gameSystemConfig.era);
 
-  useAutoFillSelect(
-    missionMatrixOptions,
-    gameSystemConfig?.missionMatrix,
-    (value: MissionMatrix) => setValue('gameSystemConfig.missionMatrix', value),
-  );
+  useAutoFillSelect(dynamicPointsVersionOptions, gameSystemConfig.dynamicPointsVersion, (value) => setValue('gameSystemConfig.dynamicPointsVersion', value));
+
+  useAutoFillSelect(missionMatrixOptions, gameSystemConfig.missionMatrix, (value) => setValue('gameSystemConfig.missionMatrix', value));
 
   return (
     <div className={clsx(styles.FlamesOfWarV4GameSystemConfigFields, className)}>
@@ -64,6 +63,13 @@ export const FlamesOfWarV4GameSystemConfigFields = ({
               disabled={lessonsFromTheFrontVersionOptions.length < 2}
             >
               <InputSelect options={lessonsFromTheFrontVersionOptions} />
+            </FormField>
+            <FormField
+              name="gameSystemConfig.dynamicPointsVersion"
+              label="Dynamic Points Version"
+              disabled={dynamicPointsVersionOptions.length < 2}
+            >
+              <InputSelect options={dynamicPointsVersionOptions} />
             </FormField>
           </div>
           <div className={styles.FlamesOfWarV4GameSystemConfigFields_Missions}>

--- a/src/components/GameSystemConfigFields/gameSystems/TeamYankeeV2GameSystemConfigFields/TeamYankeeV2GameSystemConfigFields.module.scss
+++ b/src/components/GameSystemConfigFields/gameSystems/TeamYankeeV2GameSystemConfigFields/TeamYankeeV2GameSystemConfigFields.module.scss
@@ -16,6 +16,6 @@
   }
 
   &_Rules {
-    @include flex.column;
+    @include flex.stackable;
   }
 }

--- a/src/components/GameSystemConfigFields/gameSystems/TeamYankeeV2GameSystemConfigFields/TeamYankeeV2GameSystemConfigFields.tsx
+++ b/src/components/GameSystemConfigFields/gameSystems/TeamYankeeV2GameSystemConfigFields/TeamYankeeV2GameSystemConfigFields.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import {
+  getDynamicPointsVersionOptions,
   getEraOptions,
   getFieldManual101VersionOptions,
   getMissionMatrixOptions,
   getMissionPackVersionOptions,
-  MissionMatrix,
 } from '@ianpaschal/combat-command-game-systems/teamYankeeV2';
 import clsx from 'clsx';
 
@@ -35,12 +35,11 @@ export const TeamYankeeV2GameSystemConfigFields = ({
   const missionMatrixOptions = getMissionMatrixOptions(gameSystemConfig.missionPackVersion);
   const fieldManual101VersionOptions = getFieldManual101VersionOptions();
   const missionPackVersionOptions = getMissionPackVersionOptions();
+  const dynamicPointsVersionOptions = getDynamicPointsVersionOptions(gameSystemConfig.era);
 
-  useAutoFillSelect(
-    missionMatrixOptions,
-    gameSystemConfig?.missionMatrix,
-    (value: MissionMatrix) => setValue('gameSystemConfig.missionMatrix', value),
-  );
+  useAutoFillSelect(dynamicPointsVersionOptions, gameSystemConfig.dynamicPointsVersion, (value) => setValue('gameSystemConfig.dynamicPointsVersion', value));
+
+  useAutoFillSelect(missionMatrixOptions, gameSystemConfig.missionMatrix, (value) => setValue('gameSystemConfig.missionMatrix', value));
 
   return (
     <div className={clsx(styles.TeamYankeeV2GameSystemConfigFields, className)}>
@@ -61,9 +60,16 @@ export const TeamYankeeV2GameSystemConfigFields = ({
             <FormField
               name="gameSystemConfig.fieldManual101Version"
               label="Field Manual 101 Version"
-            // disabled={fieldManual101VersionOptions.length < 2}
+              disabled={fieldManual101VersionOptions.length < 2}
             >
               <InputSelect options={fieldManual101VersionOptions} />
+            </FormField>
+            <FormField
+              name="gameSystemConfig.dynamicPointsVersion"
+              label="Dynamic Points Version"
+              disabled={dynamicPointsVersionOptions.length < 2}
+            >
+              <InputSelect options={dynamicPointsVersionOptions} />
             </FormField>
           </div>
           <div className={styles.TeamYankeeV2GameSystemConfigFields_Missions}>

--- a/src/hooks/useAutoFillSelect.ts
+++ b/src/hooks/useAutoFillSelect.ts
@@ -2,17 +2,16 @@ import { useEffect } from 'react';
 import { SelectOption } from '@ianpaschal/combat-command-game-systems/common';
 
 export const useAutoFillSelect = <T extends string>(
-  options: SelectOption<T>[], // TODO: Why no MissionMatrix?
-  value: T | undefined, // TODO: Why no MissionMatrix?
+  options: SelectOption<T>[],
+  value: T | undefined,
   onAutoSet: (value: T) => void,
 ): void => {
   useEffect(() => {
-    if (options.length === 1 && !!value && value !== options[0].value) {
-      onAutoSet(options[0].value);
+    const isCurrentValueAvailable = options.some((option) => option.value === value);
+
+    if (!isCurrentValueAvailable && options.length > 0) {
+      const lastOption = options[options.length - 1];
+      onAutoSet(lastOption.value);
     }
-  }, [
-    options,
-    value,
-    onAutoSet,
-  ]);
+  }, [options, value, onAutoSet]);
 };


### PR DESCRIPTION
Resolves #281 

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Dynamic Points Version configuration option to game system settings for Flames of War and Team Yankee.

* **Improvements**
  * Enhanced auto-fill behavior for configuration fields to better handle option selection.
  * Improved responsive layout for game system rules sections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->