### PR TITLE
#283 Avoid crash on 3-char team names

### DIFF
--- a/convex/_model/common/_helpers/getCountryName.ts
+++ b/convex/_model/common/_helpers/getCountryName.ts
@@ -1,6 +1,9 @@
 import { country, subdivision } from 'iso-3166-2';
 
-export const getCountryName = (code: string): string | undefined => {
+export const getCountryName = (code: string | undefined): string | undefined => {
+  if (!code) {
+    return undefined;
+  }
   if (code === 'xx-lkt') {
     return 'Landsknechte';
   }
@@ -14,7 +17,15 @@ export const getCountryName = (code: string): string | undefined => {
     return 'United Nations';
   }
   if (code.includes('-')) {
-    return subdivision(code)?.name;
+    try {
+      return subdivision(code)?.name;
+    } catch {
+      return undefined;
+    }
   }
-  return country(code)?.name;
+  try {
+    return country(code)?.name;
+  } catch {
+    return undefined;
+  }
 };

--- a/src/utils/common/getCountryName.ts
+++ b/src/utils/common/getCountryName.ts
@@ -1,6 +1,9 @@
 import { country, subdivision } from 'iso-3166-2';
 
-export const getCountryName = (code: string): string | undefined => {
+export const getCountryName = (code: string | undefined): string | undefined => {
+  if (!code) {
+    return undefined;
+  }
   if (code === 'xx-lkt') {
     return 'Landsknechte';
   }
@@ -14,7 +17,15 @@ export const getCountryName = (code: string): string | undefined => {
     return 'United Nations';
   }
   if (code.includes('-')) {
-    return subdivision(code)?.name;
+    try {
+      return subdivision(code)?.name;
+    } catch {
+      return undefined;
+    }
   }
-  return country(code)?.name;
+  try {
+    return country(code)?.name;
+  } catch {
+    return undefined;
+  }
 };


### PR DESCRIPTION
Resolves #283 

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced robustness of country and region name lookups. The system now gracefully handles edge cases and invalid inputs, preventing errors and providing consistent fallback behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->